### PR TITLE
Fix header layout on small devices

### DIFF
--- a/sass/css/layout/_mobile_header_fix.scss
+++ b/sass/css/layout/_mobile_header_fix.scss
@@ -1,0 +1,17 @@
+@include breakpoint('<=xsmall') {
+	#header {
+		height: unset;
+		display: flex;
+		flex-wrap: wrap;
+		justify-content: flex-start;
+		align-items: center;
+	}
+
+	#header > nav {
+		position: unset;
+		height: unset !important;
+		line-height: normal !important;
+		padding-bottom: 1em;
+		margin-left: auto;
+	}
+}

--- a/sass/css/main.scss
+++ b/sass/css/main.scss
@@ -56,5 +56,6 @@
 	@import 'layout/banner';
 	@import 'layout/wrapper';
 	@import 'layout/footer';
+	@import 'layout/mobile_header_fix';
 
 


### PR DESCRIPTION
For xs devices the header would overlap with the "Join Discord" text, causing it to be quite unreadable. This patch forces the elements to properly layout in two lines instead on small devices.