### PR TITLE
Replace invalid invites in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Server beitreten](https://discordapp.com/api/guilds/501365485837877268/widget.png?style=shield)](https://discord.com/invite/kit) ![Rohrlinienstatus](https://github.com/chrisliebaer/kitmatheinfo-website/actions/workflows/build-docker.yml/badge.svg)
+[![Server beitreten](https://discordapp.com/api/guilds/501365485837877268/widget.png?style=shield)](https://discord.gg/jMmYM5b3jT) ![Rohrlinienstatus](https://github.com/chrisliebaer/kitmatheinfo-website/actions/workflows/build-docker.yml/badge.svg)
 
 Dieses Depot verwaltet den Inhalt und den Generator der https://kitmatheinfo.de Website. Wir sind ein studentischer Discordserver für die Fachrichtungen Informatik und Mathematik am Karlsruher Institut für Technologie. Wir versuchen eine einfache Möglichkeit für Studenten zu bieten, welche sich online mit Gleichgesinnten über ihr Studium oder das Leben an der Universtität unterhalten wollen.
 
@@ -6,4 +6,4 @@ Wir haben außerdem Channel für verschiedene Module, in welchen ihr den Vorlesu
 
 Änderungen und Erweiterungen der Website sind ebenfalls gerne als Pull Request willkommen.
 
-[![Server beitreten](https://discordapp.com/api/guilds/501365485837877268/widget.png?style=banner1)](https://discord.com/invite/kit)
+[![Server beitreten](https://discordapp.com/api/guilds/501365485837877268/widget.png?style=banner1)](https://discord.gg/jMmYM5b3jT)


### PR DESCRIPTION
"https://discord.com/invite/kit" is not an invite of 'KIT Mathe Info' anymore.