### PR TITLE
Change social image url

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -12,6 +12,6 @@ external_links_no_referrer = true
 smart_punctuation = true
 
 [extra]
-social_image = "https://kitmatheinfo.de/icon/jMmYM5b3jT"
+social_image = "https://icon.kitmatheinfo.de/jMmYM5b3jT"
 discord_invite = "https://discord.gg/jMmYM5b3jT"
 github_repo = "https://github.com/kitmatheinfo/kitmatheinfo-website"


### PR DESCRIPTION
The new vercel deployment doesn't allow different services on `/icon`.